### PR TITLE
shell.CommandPrompt: flush the output buffer to show the command prompt

### DIFF
--- a/src/main/java/net/kemitix/journal/shell/CommandPrompt.java
+++ b/src/main/java/net/kemitix/journal/shell/CommandPrompt.java
@@ -56,6 +56,7 @@ public class CommandPrompt {
         try {
             while (applicationState.get("running", Boolean.class).isPresent()) {
                 output.print("> ");
+                output.flush();
                 val input = reader.readLine();
                 if (input == null) {
                     applicationState.remove("running");


### PR DESCRIPTION
Not writing a newline means that the autoflush doesn't trigger when we only write part of a line.