### PR TITLE
Handle invalid input dates

### DIFF
--- a/src/main/java/net/kemitix/journal/shell/CommandHandlerException.java
+++ b/src/main/java/net/kemitix/journal/shell/CommandHandlerException.java
@@ -7,6 +7,11 @@ package net.kemitix.journal.shell;
  */
 public class CommandHandlerException extends RuntimeException {
 
+    /**
+     * Constructor.
+     * @param message the message to display to the user
+     * @param cause the cause
+     */
     public CommandHandlerException(
             final String message, final Exception cause) {
         super(message, cause);

--- a/src/main/java/net/kemitix/journal/shell/CommandHandlerException.java
+++ b/src/main/java/net/kemitix/journal/shell/CommandHandlerException.java
@@ -1,0 +1,14 @@
+package net.kemitix.journal.shell;
+
+/**
+ * Exception for error occurring within a CommandHandler..
+ *
+ * @author pcampbell
+ */
+public class CommandHandlerException extends RuntimeException {
+
+    public CommandHandlerException(
+            final String message, final Exception cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/net/kemitix/journal/shell/CommandPrompt.java
+++ b/src/main/java/net/kemitix/journal/shell/CommandPrompt.java
@@ -68,8 +68,12 @@ public class CommandPrompt {
                     // dispatch command
                     if (commandMapping.isPresent()) {
                         val mapping = commandMapping.get();
-                        output.println(
-                                mapping.getHandler().handle(mapping.getArgs()));
+                        try {
+                            output.println(mapping.getHandler()
+                                                  .handle(mapping.getArgs()));
+                        } catch (CommandHandlerException e) {
+                            output.println("Error: " + e.getMessage());
+                        }
                     } else {
                         output.println("Not a recognised command!");
                     }

--- a/src/main/java/net/kemitix/journal/shell/commands/DailyCreateHandler.java
+++ b/src/main/java/net/kemitix/journal/shell/commands/DailyCreateHandler.java
@@ -89,16 +89,13 @@ class DailyCreateHandler extends AbstractCommandHandler {
         LocalDate date;
         List<String> output = new ArrayList<>();
         if (args.containsKey("date")) {
-            date = LocalDate.parse(args.get("date"));
             output.add(dateSetHandler.handle(args));
+        }
+        val dateOptional = applicationState.get(SELECTED_DATE, LocalDate.class);
+        if (dateOptional.isPresent()) {
+            date = dateOptional.get();
         } else {
-            val dateOptional = applicationState.get(SELECTED_DATE,
-                    LocalDate.class);
-            if (dateOptional.isPresent()) {
-                date = dateOptional.get();
-            } else {
-                date = LocalDate.now();
-            }
+            date = LocalDate.now();
         }
         val dailyLog = journalService.createDailyLog(date);
         output.add("Daily log created for " + dailyLog.getDate());

--- a/src/main/java/net/kemitix/journal/shell/commands/DateSetHandler.java
+++ b/src/main/java/net/kemitix/journal/shell/commands/DateSetHandler.java
@@ -2,6 +2,7 @@ package net.kemitix.journal.shell.commands;
 
 import static net.kemitix.journal.shell.CommandPrompt.SELECTED_DATE;
 
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 import net.kemitix.journal.TypeSafeMap;
 import net.kemitix.journal.shell.AbstractCommandHandler;
+import net.kemitix.journal.shell.CommandHandlerException;
 
 /**
  * Sets the application's current date to that provided. This date will be the
@@ -75,7 +77,12 @@ class DateSetHandler extends AbstractCommandHandler {
     public String handle(final Map<String, String> args) {
         LocalDate selectedDate = LocalDate.now();
         if (args.containsKey("date")) {
-            selectedDate = LocalDate.parse(args.get("date"));
+            try {
+                selectedDate = LocalDate.parse(args.get("date"));
+            } catch (DateTimeException e) {
+                throw new CommandHandlerException(
+                        "Invalid date: " + args.get("date"), e);
+            }
         }
         applicationState.put(SELECTED_DATE, selectedDate, LocalDate.class);
         return "Date set to " + selectedDate;

--- a/src/test/java/net/kemitix/journal/shell/commands/DateSetHandlerTest.java
+++ b/src/test/java/net/kemitix/journal/shell/commands/DateSetHandlerTest.java
@@ -2,7 +2,9 @@ package net.kemitix.journal.shell.commands;
 
 import lombok.val;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -14,6 +16,7 @@ import java.time.LocalDate;
 import java.util.HashMap;
 
 import net.kemitix.journal.TypeSafeMap;
+import net.kemitix.journal.shell.CommandHandlerException;
 
 /**
  * Tests for {@link DateSetHandler}.
@@ -82,6 +85,20 @@ public class DateSetHandlerTest {
         val result = handler.handle(args);
         //then
         assertThat(result).contains("Date set to " + tomorrow);
-        verify(applicationState).put("selected-date", tomorrow, LocalDate.class);
+        verify(applicationState).put("selected-date", tomorrow,
+                LocalDate.class);
+    }
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldReportWhenDateIsInvalid() {
+        //given
+        args.put("date", "2016-14-01"); // invalid month
+        exception.expect(CommandHandlerException.class);
+        exception.expectMessage("Invalid date: 2016-14-01");
+        //when
+        handler.handle(args);
     }
 }


### PR DESCRIPTION
* Errors in a CommandHandler can now be re-thrown within a CommandHandlerException with a user-friendly error message. CommandPrompt will capture these exceptions and display the message.
* DateSetHandler throws a CommandHandlerException when the date is invalid
* DateCreateHandlerTest is simplified by not attempting to mock the application state