### PR TITLE
Consistent writer usage

### DIFF
--- a/src/main/java/net/kemitix/journal/shell/CommandHandler.java
+++ b/src/main/java/net/kemitix/journal/shell/CommandHandler.java
@@ -60,9 +60,7 @@ public interface CommandHandler {
      * Handle the command.
      *
      * @param args the matched arguments
-     *
-     * @return the command output
      */
-    String handle(Map<String, String> args);
+    void handle(Map<String, String> args);
 
 }

--- a/src/main/java/net/kemitix/journal/shell/CommandPrompt.java
+++ b/src/main/java/net/kemitix/journal/shell/CommandPrompt.java
@@ -31,7 +31,7 @@ public class CommandPrompt {
 
     private final BufferedReader reader;
 
-    private final PrintWriter output;
+    private final PrintWriter writer;
 
     @Inject
     CommandPrompt(
@@ -42,7 +42,7 @@ public class CommandPrompt {
         this.commandRouter = commandRouter;
         this.applicationState = applicationState;
         this.reader = commandLineReader;
-        this.output = commandLineWriter;
+        this.writer = commandLineWriter;
     }
 
     /**
@@ -50,18 +50,18 @@ public class CommandPrompt {
      */
     @PostConstruct
     public void run() {
-        output.println("Ctrl-D to quit");
+        writer.println("Ctrl-D to quit");
         applicationState.put("running", true, Boolean.class);
         applicationState.put("selected date", LocalDate.now(), LocalDate.class);
         try {
             while (applicationState.get("running", Boolean.class).isPresent()) {
-                output.print("> ");
-                output.flush();
+                writer.print("> ");
+                writer.flush();
                 val input = reader.readLine();
                 if (input == null) {
                     applicationState.remove("running");
-                    output.println();
-                    output.println("Exiting...");
+                    writer.println();
+                    writer.println("Exiting...");
                 } else if (input.length() > 0) {
                     // look up command
                     val commandMapping = commandRouter.selectCommand(input);
@@ -69,18 +69,17 @@ public class CommandPrompt {
                     if (commandMapping.isPresent()) {
                         val mapping = commandMapping.get();
                         try {
-                            output.println(mapping.getHandler()
-                                                  .handle(mapping.getArgs()));
+                            mapping.getHandler().handle(mapping.getArgs());
                         } catch (CommandHandlerException e) {
-                            output.println("Error: " + e.getMessage());
+                            writer.println("Error: " + e.getMessage());
                         }
                     } else {
-                        output.println("Not a recognised command!");
+                        writer.println("Not a recognised command!");
                     }
                 }
             }
         } catch (IOException e) {
-            output.println("Aborting: " + e.getMessage());
+            writer.println("Aborting: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/net/kemitix/journal/shell/DefaultCommandRouter.java
+++ b/src/main/java/net/kemitix/journal/shell/DefaultCommandRouter.java
@@ -2,6 +2,7 @@ package net.kemitix.journal.shell;
 
 import lombok.val;
 
+import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,11 +25,15 @@ class DefaultCommandRouter implements CommandRouter {
 
     private final List<CommandHandler> handlerList;
 
+    private final PrintWriter writer;
+
     private Map<Pattern, CommandHandler> commandMap;
 
     @Inject
-    DefaultCommandRouter(final List<CommandHandler> handlerList) {
+    DefaultCommandRouter(
+            final List<CommandHandler> handlerList, final PrintWriter writer) {
         this.handlerList = handlerList;
+        this.writer = writer;
     }
 
     @PostConstruct
@@ -60,12 +65,12 @@ class DefaultCommandRouter implements CommandRouter {
             return Optional.of(mapping);
         }
         if (!matching.isEmpty()) {
-            System.out.println("Command matches multiple commands:");
+            writer.println("Command matches multiple commands:");
             matching.stream()
                     .map(p -> commandMap.get(p))
                     .map(CommandHandler::getSyntax)
                     .map(s -> "- " + s)
-                    .forEach(System.out::println);
+                    .forEach(writer::println);
         }
         return Optional.empty();
     }

--- a/src/main/java/net/kemitix/journal/shell/commands/ApplicationExitHandler.java
+++ b/src/main/java/net/kemitix/journal/shell/commands/ApplicationExitHandler.java
@@ -1,5 +1,6 @@
 package net.kemitix.journal.shell.commands;
 
+import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -8,8 +9,8 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
 
-import net.kemitix.journal.shell.AbstractCommandHandler;
 import net.kemitix.journal.TypeSafeMap;
+import net.kemitix.journal.shell.AbstractCommandHandler;
 
 /**
  * Exit handler.
@@ -24,9 +25,13 @@ class ApplicationExitHandler extends AbstractCommandHandler {
 
     private final TypeSafeMap applicationState;
 
+    private final PrintWriter writer;
+
     @Inject
-    ApplicationExitHandler(final TypeSafeMap applicationState) {
+    ApplicationExitHandler(
+            final TypeSafeMap applicationState, final PrintWriter writer) {
         this.applicationState = applicationState;
+        this.writer = writer;
     }
 
     @Override
@@ -40,8 +45,8 @@ class ApplicationExitHandler extends AbstractCommandHandler {
     }
 
     @Override
-    public String handle(final Map<String, String> args) {
+    public void handle(final Map<String, String> args) {
         applicationState.remove("running");
-        return "Exiting...";
+        writer.println("Exiting...");
     }
 }

--- a/src/main/java/net/kemitix/journal/shell/commands/DailyCreateHandler.java
+++ b/src/main/java/net/kemitix/journal/shell/commands/DailyCreateHandler.java
@@ -4,8 +4,8 @@ import lombok.val;
 
 import static net.kemitix.journal.shell.CommandPrompt.SELECTED_DATE;
 
+import java.io.PrintWriter;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -44,14 +44,17 @@ class DailyCreateHandler extends AbstractCommandHandler {
 
     private final TypeSafeMap applicationState;
 
+    private final PrintWriter writer;
+
     @Inject
     DailyCreateHandler(
             final JournalService journalService,
             final DateSetHandler dateSetHandler,
-            final TypeSafeMap applicationState) {
+            final TypeSafeMap applicationState, final PrintWriter writer) {
         this.journalService = journalService;
         this.dateSetHandler = dateSetHandler;
         this.applicationState = applicationState;
+        this.writer = writer;
     }
 
     @Override
@@ -84,12 +87,11 @@ class DailyCreateHandler extends AbstractCommandHandler {
     }
 
     @Override
-    public String handle(
+    public void handle(
             final Map<String, String> args) {
         LocalDate date;
-        List<String> output = new ArrayList<>();
         if (args.containsKey("date")) {
-            output.add(dateSetHandler.handle(args));
+            dateSetHandler.handle(args);
         }
         val dateOptional = applicationState.get(SELECTED_DATE, LocalDate.class);
         if (dateOptional.isPresent()) {
@@ -98,8 +100,7 @@ class DailyCreateHandler extends AbstractCommandHandler {
             date = LocalDate.now();
         }
         val dailyLog = journalService.createDailyLog(date);
-        output.add("Daily log created for " + dailyLog.getDate());
-        return String.join("\n", output);
+        writer.println("Daily log created for " + dailyLog.getDate());
     }
 
 }

--- a/src/main/java/net/kemitix/journal/shell/commands/DailyListHandler.java
+++ b/src/main/java/net/kemitix/journal/shell/commands/DailyListHandler.java
@@ -1,11 +1,11 @@
 package net.kemitix.journal.shell.commands;
 
+import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -28,10 +28,13 @@ class DailyListHandler extends AbstractCommandHandler {
 
     private final JournalService journalService;
 
+    private final PrintWriter writer;
+
     @Inject
     DailyListHandler(
-            final JournalService journalService) {
+            final JournalService journalService, final PrintWriter writer) {
         this.journalService = journalService;
+        this.writer = writer;
     }
 
     @Override
@@ -45,15 +48,15 @@ class DailyListHandler extends AbstractCommandHandler {
     }
 
     @Override
-    public String handle(final Map<String, String> args) {
+    public void handle(final Map<String, String> args) {
         final List<DailyLog> all = journalService.getAllDailyLogs();
         if (all.size() == 0) {
-            return "No Daily Logs found";
+            writer.println("No Daily Logs found");
         }
-        return all.stream()
+        all.stream()
                   .sorted(sortByDate())
                   .map(dailyLogSummary())
-                  .collect(Collectors.joining("\n"));
+                  .forEach(writer::println);
     }
 
     private Function<DailyLog, String> dailyLogSummary() {

--- a/src/main/java/net/kemitix/journal/shell/commands/DateSetHandler.java
+++ b/src/main/java/net/kemitix/journal/shell/commands/DateSetHandler.java
@@ -2,6 +2,7 @@ package net.kemitix.journal.shell.commands;
 
 import static net.kemitix.journal.shell.CommandPrompt.SELECTED_DATE;
 
+import java.io.PrintWriter;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -39,9 +40,13 @@ class DateSetHandler extends AbstractCommandHandler {
 
     private final TypeSafeMap applicationState;
 
+    private final PrintWriter writer;
+
     @Inject
-    DateSetHandler(final TypeSafeMap applicationState) {
+    DateSetHandler(
+            final TypeSafeMap applicationState, final PrintWriter writer) {
         this.applicationState = applicationState;
+        this.writer = writer;
     }
 
     @Override
@@ -74,7 +79,7 @@ class DateSetHandler extends AbstractCommandHandler {
     }
 
     @Override
-    public String handle(final Map<String, String> args) {
+    public void handle(final Map<String, String> args) {
         LocalDate selectedDate = LocalDate.now();
         if (args.containsKey("date")) {
             try {
@@ -85,6 +90,6 @@ class DateSetHandler extends AbstractCommandHandler {
             }
         }
         applicationState.put(SELECTED_DATE, selectedDate, LocalDate.class);
-        return "Date set to " + selectedDate;
+        writer.println("Date set to " + selectedDate);
     }
 }

--- a/src/main/java/net/kemitix/journal/shell/commands/HelpDisplayHandler.java
+++ b/src/main/java/net/kemitix/journal/shell/commands/HelpDisplayHandler.java
@@ -1,9 +1,9 @@
 package net.kemitix.journal.shell.commands;
 
+import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -25,9 +25,13 @@ class HelpDisplayHandler extends AbstractCommandHandler {
 
     private final List<CommandHandler> handlerList;
 
+    private final PrintWriter writer;
+
     @Inject
-    HelpDisplayHandler(final List<CommandHandler> handlerList) {
+    HelpDisplayHandler(
+            final List<CommandHandler> handlerList, final PrintWriter writer) {
         this.handlerList = handlerList;
+        this.writer = writer;
     }
 
     @Override
@@ -41,11 +45,11 @@ class HelpDisplayHandler extends AbstractCommandHandler {
     }
 
     @Override
-    public String handle(final Map<String, String> args) {
-        return "The following commands are available:\n" + String.join("\n",
-                handlerList.stream()
-                           .map(CommandHandler::getUsage)
-                           .collect(Collectors.toList()));
+    public void handle(final Map<String, String> args) {
+        writer.println("The following commands are available:");
+        handlerList.stream()
+                   .map(CommandHandler::getUsage)
+                   .forEach(writer::println);
     }
 
 }

--- a/src/test/java/net/kemitix/journal/shell/AbstractCommandHandlerTest.java
+++ b/src/test/java/net/kemitix/journal/shell/AbstractCommandHandlerTest.java
@@ -32,8 +32,7 @@ public class AbstractCommandHandlerTest {
             }
 
             @Override
-            public String handle(final Map<String, String> args) {
-                return null;
+            public void handle(final Map<String, String> args) {
             }
         };
     }

--- a/src/test/java/net/kemitix/journal/shell/CommandPromptTest.java
+++ b/src/test/java/net/kemitix/journal/shell/CommandPromptTest.java
@@ -8,6 +8,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.startsWith;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
@@ -38,20 +39,20 @@ public class CommandPromptTest {
     private BufferedReader reader;
 
     @Mock
-    private PrintWriter output;
-
-    @Mock
     private CommandMapping commandMapping;
 
     @Mock
     private CommandHandler commandHandler;
+
+    @Mock
+    private PrintWriter writer;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         applicationState = new TypeSafeHashMap();
         prompt = new CommandPrompt(commandRouter, applicationState, reader,
-                output);
+                writer);
     }
 
     @Test
@@ -60,7 +61,7 @@ public class CommandPromptTest {
         doThrow(IOException.class).when(reader).readLine();
         //when
         prompt.run();
-        verify(output).println(startsWith("Aborting: "));
+        verify(writer).println(startsWith("Aborting: "));
     }
 
     @Test
@@ -70,7 +71,7 @@ public class CommandPromptTest {
         //when
         prompt.run();
         //then
-        verify(output).println("Exiting...");
+        verify(writer).println("Exiting...");
     }
 
     @Test
@@ -80,7 +81,7 @@ public class CommandPromptTest {
         //when
         prompt.run();
         //then
-        verify(output).println("Exiting...");
+        verify(writer).println("Exiting...");
     }
 
     @Test
@@ -92,11 +93,14 @@ public class CommandPromptTest {
         given(commandMapping.getHandler()).willReturn(commandHandler);
         val args = new HashMap<String, String>();
         given(commandMapping.getArgs()).willReturn(args);
-        given(commandHandler.handle(args)).willReturn("expected output");
+        doAnswer(i -> {
+            writer.println("expected output");
+            return null;
+        }).when(commandHandler).handle(args);
         //when
         prompt.run();
         //then
-        verify(output).println("expected output");
+        verify(writer).println("expected output");
     }
 
     @Test
@@ -108,7 +112,7 @@ public class CommandPromptTest {
         //when
         prompt.run();
         //then
-        verify(output).println("Not a recognised command!");
+        verify(writer).println("Not a recognised command!");
     }
 
 }

--- a/src/test/java/net/kemitix/journal/shell/DefaultCommandRouterTest.java
+++ b/src/test/java/net/kemitix/journal/shell/DefaultCommandRouterTest.java
@@ -11,7 +11,9 @@ import org.mockito.MockitoAnnotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Optional;
@@ -28,11 +30,14 @@ public class DefaultCommandRouterTest {
 
     private ArrayList<CommandHandler> handlers;
 
+    @Mock
+    private PrintWriter writer;
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         handlers = new ArrayList<>();
-        router = new DefaultCommandRouter(handlers);
+        router = new DefaultCommandRouter(handlers, writer);
     }
 
     @Test
@@ -137,10 +142,9 @@ public class DefaultCommandRouterTest {
         handlers.add(CommandFactory.builder().command("test").build().create());
         router.init();
         //when
-        val result = router.selectCommand("test");
+        router.selectCommand("test");
         //then
-        assertThat(result.isPresent()).as(
-                "match nothing if more multiple command match").isFalse();
+        verify(writer).println("Command matches multiple commands:");
     }
 
     @Getter

--- a/src/test/java/net/kemitix/journal/shell/commands/ApplicationExitHandlerTest.java
+++ b/src/test/java/net/kemitix/journal/shell/commands/ApplicationExitHandlerTest.java
@@ -9,6 +9,7 @@ import org.mockito.MockitoAnnotations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
+import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,6 +30,9 @@ public class ApplicationExitHandlerTest {
 
     private Map<String, String> args;
 
+    @Mock
+    private PrintWriter writer;
+
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
@@ -48,9 +52,9 @@ public class ApplicationExitHandlerTest {
     @Test
     public void shouldHandle() throws Exception {
         //when
-        final String result = handler.handle(args);
+        handler.handle(args);
         //then
-        assertThat(result).contains("Exiting");
+        verify(writer).println("Exiting...");
         verify(applicationState).remove("running");
     }
 

--- a/src/test/java/net/kemitix/journal/shell/commands/DailyListHandlerTest.java
+++ b/src/test/java/net/kemitix/journal/shell/commands/DailyListHandlerTest.java
@@ -9,7 +9,9 @@ import org.mockito.MockitoAnnotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
+import java.io.PrintWriter;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,6 +55,9 @@ public class DailyListHandlerTest {
     @Mock
     private LogEntry logEntry3;
 
+    @Mock
+    private PrintWriter writer;
+
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
@@ -75,9 +80,9 @@ public class DailyListHandlerTest {
         given(journalService.getAllDailyLogs()).willReturn(
                 Collections.emptyList());
         //when
-        val result = handler.handle(args);
+        handler.handle(args);
         //then
-        assertThat(result).contains("No Daily Logs found");
+        verify(writer).println("No Daily Logs found");
     }
 
     @Test
@@ -94,11 +99,11 @@ public class DailyListHandlerTest {
         given(journalService.getAllDailyLogs()).willReturn(
                 Arrays.asList(logTomorrow, logToday, logYesterday));
         //when
-        val result = handler.handle(args);
+        handler.handle(args);
         //then
-        assertThat(result).contains(
-                "- " + tomorrow + ": 1 item(s)\n" + "- " + today
-                        + ": 0 item(s)\n" + "- " + yesterday + ": 0 item(s)");
+        verify(writer).println("- " + tomorrow + ": 1 item(s)");
+        verify(writer).println("- " + today + ": 0 item(s)");
+        verify(writer).println("- " + yesterday + ": 0 item(s)");
     }
 
 }

--- a/src/test/java/net/kemitix/journal/shell/commands/DailyShowHandlerTest.java
+++ b/src/test/java/net/kemitix/journal/shell/commands/DailyShowHandlerTest.java
@@ -1,7 +1,6 @@
 package net.kemitix.journal.shell.commands;
 
 import lombok.val;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -10,7 +9,9 @@ import org.mockito.MockitoAnnotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
+import java.io.PrintWriter;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,6 +47,9 @@ public class DailyShowHandlerTest {
     @Mock
     private LogEntry logEntry2;
 
+    @Mock
+    private PrintWriter writer;
+
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
@@ -76,12 +80,10 @@ public class DailyShowHandlerTest {
         given(logEntry1.getTitle()).willReturn("entry 1");
         given(logEntry2.getTitle()).willReturn("entry 2");
         //when
-        val result = handler.handle(new HashMap<>());
+        handler.handle(new HashMap<>());
         //then
-        val softly = new SoftAssertions();
-        softly.assertThat(result).contains("1: a entry 1");
-        softly.assertThat(result).contains("2: b entry 2");
-        softly.assertAll();
+        verify(writer).println(" 1: a entry 1");
+        verify(writer).println(" 2: b entry 2");
     }
 
 }

--- a/src/test/java/net/kemitix/journal/shell/commands/DateSetHandlerTest.java
+++ b/src/test/java/net/kemitix/journal/shell/commands/DateSetHandlerTest.java
@@ -12,6 +12,7 @@ import org.mockito.MockitoAnnotations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
+import java.io.PrintWriter;
 import java.time.LocalDate;
 import java.util.HashMap;
 
@@ -30,6 +31,9 @@ public class DateSetHandlerTest {
 
     @Mock
     private TypeSafeMap applicationState;
+
+    @Mock
+    private PrintWriter writer;
 
     private LocalDate today;
 
@@ -70,9 +74,9 @@ public class DateSetHandlerTest {
     @Test
     public void shouldHandleWithNoArgs() throws Exception {
         //when
-        val result = handler.handle(args);
+        handler.handle(args);
         //then
-        assertThat(result).contains("Date set to " + today);
+        verify(writer).println("Date set to " + today);
         verify(applicationState).put("selected-date", today, LocalDate.class);
     }
 
@@ -82,9 +86,9 @@ public class DateSetHandlerTest {
         val tomorrow = LocalDate.now().plusDays(1);
         args.put("date", tomorrow.toString());
         //when
-        val result = handler.handle(args);
+        handler.handle(args);
         //then
-        assertThat(result).contains("Date set to " + tomorrow);
+        verify(writer).println("Date set to " + tomorrow);
         verify(applicationState).put("selected-date", tomorrow,
                 LocalDate.class);
     }

--- a/src/test/java/net/kemitix/journal/shell/commands/HelpDisplayHandlerTest.java
+++ b/src/test/java/net/kemitix/journal/shell/commands/HelpDisplayHandlerTest.java
@@ -1,6 +1,5 @@
 package net.kemitix.journal.shell.commands;
 
-import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -8,7 +7,9 @@ import org.mockito.MockitoAnnotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -29,11 +30,14 @@ public class HelpDisplayHandlerTest {
     @Mock
     private CommandHandler mockHandler;
 
+    @Mock
+    private PrintWriter writer;
+
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         handlerList = new ArrayList<>();
-        handler = new HelpDisplayHandler(handlerList);
+        handler = new HelpDisplayHandler(handlerList, writer);
     }
 
     @Test
@@ -52,10 +56,10 @@ public class HelpDisplayHandlerTest {
         handlerList.add(mockHandler);
         given(mockHandler.getUsage()).willReturn("mock usage");
         //when
-        val result = handler.handle(new HashMap<>());
+        handler.handle(new HashMap<>());
         //then
-        assertThat(result).contains("The following commands are available");
-        assertThat(result).contains("mock usage");
+        verify(writer).println("The following commands are available:");
+        verify(writer).println("mock usage");
     }
 
 }


### PR DESCRIPTION
* Replace all System.out usage with the PrintWriter Bean
* Consistently refer to the PrintWriter Bean using a field 'writer'
* CommandHandler implementations use the PrintWriter directly rather than pass output back to called