### PR TITLE
Add simpler interface to manage the application state

### DIFF
--- a/src/main/java/net/kemitix/journal/SpringBootJournal.java
+++ b/src/main/java/net/kemitix/journal/SpringBootJournal.java
@@ -9,8 +9,7 @@ import java.io.PrintWriter;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties
-        .EnableConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
 /**
@@ -42,8 +41,4 @@ public class SpringBootJournal {
         return new PrintWriter(new OutputStreamWriter(System.out, UTF_8), true);
     }
 
-    @Bean
-    TypeSafeMap applicationState() {
-        return new TypeSafeHashMap();
-    }
 }

--- a/src/main/java/net/kemitix/journal/shell/ShellState.java
+++ b/src/main/java/net/kemitix/journal/shell/ShellState.java
@@ -44,7 +44,7 @@ public interface ShellState {
      * that they can select on of them later using {@link
      * #getLogEntryFromList(Integer)}.
      *
-     * @param list
+     * @param list the list of log entries
      */
     void setLogEntryList(LogEntryList list);
 

--- a/src/main/java/net/kemitix/journal/shell/ShellState.java
+++ b/src/main/java/net/kemitix/journal/shell/ShellState.java
@@ -1,0 +1,60 @@
+package net.kemitix.journal.shell;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import net.kemitix.journal.LogEntryList;
+import net.kemitix.journal.model.LogEntry;
+
+/**
+ * Interface for maintaining the state of the shell.
+ *
+ * @author pcampbell
+ */
+public interface ShellState {
+
+    /**
+     * Sets the state to shutdown at the next opportunity.
+     */
+    void shutdown();
+
+    /**
+     * Returns true if the {@link #shutdown()} method has been called.
+     *
+     * @return true if shutting down
+     */
+    boolean isShuttingDown();
+
+    /**
+     * Selects the date as the new default date.
+     *
+     * @param date the default date
+     */
+    void setDefaultDate(LocalDate date);
+
+    /**
+     * Returns the current default date.
+     *
+     * @return the default date
+     */
+    LocalDate getDefaultDate();
+
+    /**
+     * Stashes a list log entries. The user should have just seen this list, so
+     * that they can select on of them later using {@link
+     * #getLogEntryFromList(Integer)}.
+     *
+     * @param list
+     */
+    void setLogEntryList(LogEntryList list);
+
+    /**
+     * Returns the indexed LogEntry from the stashed LogEntryList.
+     *
+     * @param index the 0-based index of the entry to return
+     *
+     * @return an Optional containing the LogEntry, or empty if none found
+     */
+    Optional<LogEntry> getLogEntryFromList(Integer index);
+
+}

--- a/src/main/java/net/kemitix/journal/shell/TypeSafeMapShellState.java
+++ b/src/main/java/net/kemitix/journal/shell/TypeSafeMapShellState.java
@@ -20,12 +20,17 @@ import net.kemitix.journal.model.LogEntry;
  * @author pcampbell
  */
 @Component
-class TypeSafeMapShellState implements ShellState {
+public class TypeSafeMapShellState implements ShellState {
 
     private final TypeSafeMap map;
 
+    /**
+     * Constructor.
+     *
+     * @param map the map for storage
+     */
     @Inject
-    TypeSafeMapShellState(final TypeSafeMap map) {
+    public TypeSafeMapShellState(final TypeSafeMap map) {
         this.map = map;
     }
 

--- a/src/main/java/net/kemitix/journal/shell/TypeSafeMapShellState.java
+++ b/src/main/java/net/kemitix/journal/shell/TypeSafeMapShellState.java
@@ -1,0 +1,66 @@
+package net.kemitix.journal.shell;
+
+import lombok.val;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import net.kemitix.journal.LogEntryList;
+import net.kemitix.journal.TypeSafeMap;
+import net.kemitix.journal.model.LogEntry;
+
+/**
+ * An implementation of the ShellState interface using a {@link TypeSafeMap} for
+ * storage.
+ *
+ * @author pcampbell
+ */
+@Component
+class TypeSafeMapShellState implements ShellState {
+
+    private final TypeSafeMap map;
+
+    @Inject
+    TypeSafeMapShellState(final TypeSafeMap map) {
+        this.map = map;
+    }
+
+    @Override
+    public void shutdown() {
+        map.put("shutting-down", Boolean.TRUE, Boolean.class);
+    }
+
+    @Override
+    public boolean isShuttingDown() {
+        return map.get("shutting-down", Boolean.class).isPresent();
+    }
+
+    @Override
+    public void setDefaultDate(final LocalDate date) {
+        map.put("default-date", date, LocalDate.class);
+    }
+
+    @Override
+    public LocalDate getDefaultDate() {
+        return map.get("default-date", LocalDate.class)
+                  .orElseGet(LocalDate::now);
+    }
+
+    @Override
+    public void setLogEntryList(final LogEntryList list) {
+        map.put("log-entry-list", list, LogEntryList.class);
+    }
+
+    @Override
+    public Optional<LogEntry> getLogEntryFromList(final Integer index) {
+        val optionalList = map.get("log-entry-list", LogEntryList.class);
+        if (optionalList.isPresent()) {
+            return Optional.ofNullable(optionalList.get().get(index));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/net/kemitix/journal/shell/commands/ApplicationExitHandler.java
+++ b/src/main/java/net/kemitix/journal/shell/commands/ApplicationExitHandler.java
@@ -9,8 +9,8 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
 
-import net.kemitix.journal.TypeSafeMap;
 import net.kemitix.journal.shell.AbstractCommandHandler;
+import net.kemitix.journal.shell.ShellState;
 
 /**
  * Exit handler.
@@ -23,14 +23,14 @@ class ApplicationExitHandler extends AbstractCommandHandler {
     private static final List<String> ALIASES = Arrays.asList("exit", "quit",
             "bye");
 
-    private final TypeSafeMap applicationState;
+    private final ShellState shellState;
 
     private final PrintWriter writer;
 
     @Inject
     ApplicationExitHandler(
-            final TypeSafeMap applicationState, final PrintWriter writer) {
-        this.applicationState = applicationState;
+            final ShellState shellState, final PrintWriter writer) {
+        this.shellState = shellState;
         this.writer = writer;
     }
 
@@ -46,7 +46,7 @@ class ApplicationExitHandler extends AbstractCommandHandler {
 
     @Override
     public void handle(final Map<String, String> args) {
-        applicationState.remove("running");
+        shellState.shutdown();
         writer.println("Exiting...");
     }
 }

--- a/src/main/java/net/kemitix/journal/shell/commands/DailyCreateHandler.java
+++ b/src/main/java/net/kemitix/journal/shell/commands/DailyCreateHandler.java
@@ -1,11 +1,6 @@
 package net.kemitix.journal.shell.commands;
 
-import lombok.val;
-
-import static net.kemitix.journal.shell.CommandPrompt.SELECTED_DATE;
-
 import java.io.PrintWriter;
-import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -17,9 +12,9 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
 
-import net.kemitix.journal.TypeSafeMap;
 import net.kemitix.journal.service.JournalService;
 import net.kemitix.journal.shell.AbstractCommandHandler;
+import net.kemitix.journal.shell.ShellState;
 
 /**
  * Create a Daily Log for the supplied date, or today if none given.
@@ -42,18 +37,18 @@ class DailyCreateHandler extends AbstractCommandHandler {
 
     private final DateSetHandler dateSetHandler;
 
-    private final TypeSafeMap applicationState;
+    private final ShellState shellState;
 
     private final PrintWriter writer;
 
     @Inject
     DailyCreateHandler(
             final JournalService journalService,
-            final DateSetHandler dateSetHandler,
-            final TypeSafeMap applicationState, final PrintWriter writer) {
+            final DateSetHandler dateSetHandler, final ShellState shellState,
+            final PrintWriter writer) {
         this.journalService = journalService;
         this.dateSetHandler = dateSetHandler;
-        this.applicationState = applicationState;
+        this.shellState = shellState;
         this.writer = writer;
     }
 
@@ -89,18 +84,11 @@ class DailyCreateHandler extends AbstractCommandHandler {
     @Override
     public void handle(
             final Map<String, String> args) {
-        LocalDate date;
         if (args.containsKey("date")) {
             dateSetHandler.handle(args);
         }
-        val dateOptional = applicationState.get(SELECTED_DATE, LocalDate.class);
-        if (dateOptional.isPresent()) {
-            date = dateOptional.get();
-        } else {
-            date = LocalDate.now();
-        }
-        val dailyLog = journalService.createDailyLog(date);
-        writer.println("Daily log created for " + dailyLog.getDate());
+        writer.println("Daily log created for " + journalService.createDailyLog(
+                shellState.getDefaultDate()).getDate());
     }
 
 }

--- a/src/main/java/net/kemitix/journal/shell/commands/DailyShowHandler.java
+++ b/src/main/java/net/kemitix/journal/shell/commands/DailyShowHandler.java
@@ -3,7 +3,6 @@ package net.kemitix.journal.shell.commands;
 import lombok.val;
 
 import java.io.PrintWriter;
-import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -15,9 +14,9 @@ import org.springframework.stereotype.Service;
 
 import net.kemitix.journal.LogEntryGlyphs;
 import net.kemitix.journal.LogEntryList;
-import net.kemitix.journal.TypeSafeMap;
 import net.kemitix.journal.service.JournalService;
 import net.kemitix.journal.shell.AbstractCommandHandler;
+import net.kemitix.journal.shell.ShellState;
 
 /**
  * Show the log entries for the currently selected date.
@@ -32,7 +31,7 @@ class DailyShowHandler extends AbstractCommandHandler {
 
     private final JournalService service;
 
-    private final TypeSafeMap state;
+    private final ShellState shellState;
 
     private final LogEntryGlyphs glyphs;
 
@@ -40,11 +39,10 @@ class DailyShowHandler extends AbstractCommandHandler {
 
     @Inject
     DailyShowHandler(
-            final JournalService journalService,
-            final TypeSafeMap applicationState, final LogEntryGlyphs glyphs,
-            final PrintWriter writer) {
+            final JournalService journalService, final ShellState shellState,
+            final LogEntryGlyphs glyphs, final PrintWriter writer) {
         this.service = journalService;
-        this.state = applicationState;
+        this.shellState = shellState;
         this.glyphs = glyphs;
         this.writer = writer;
     }
@@ -63,9 +61,8 @@ class DailyShowHandler extends AbstractCommandHandler {
     public void handle(final Map<String, String> args) {
         // get log entries for args.'date' and place in state.'log entries'
         val entries = new LogEntryList();
-        state.get("selected date", LocalDate.class)
-             .ifPresent(date -> entries.addAll(service.getLogs(date)));
-        state.put("log entries", entries, LogEntryList.class);
+        entries.addAll(service.getLogs(shellState.getDefaultDate()));
+        shellState.setLogEntryList(entries);
         // write as a list with index and glyph
         AtomicInteger index = new AtomicInteger(0);
         entries.stream()

--- a/src/main/java/net/kemitix/journal/shell/commands/DateSetHandler.java
+++ b/src/main/java/net/kemitix/journal/shell/commands/DateSetHandler.java
@@ -1,7 +1,5 @@
 package net.kemitix.journal.shell.commands;
 
-import static net.kemitix.journal.shell.CommandPrompt.SELECTED_DATE;
-
 import java.io.PrintWriter;
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -16,9 +14,9 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
 
-import net.kemitix.journal.TypeSafeMap;
 import net.kemitix.journal.shell.AbstractCommandHandler;
 import net.kemitix.journal.shell.CommandHandlerException;
+import net.kemitix.journal.shell.ShellState;
 
 /**
  * Sets the application's current date to that provided. This date will be the
@@ -38,14 +36,14 @@ class DateSetHandler extends AbstractCommandHandler {
     private static final List<String> PARAMETER_NAMES
             = Collections.singletonList("date");
 
-    private final TypeSafeMap applicationState;
+    private final ShellState shellState;
 
     private final PrintWriter writer;
 
     @Inject
     DateSetHandler(
-            final TypeSafeMap applicationState, final PrintWriter writer) {
-        this.applicationState = applicationState;
+            final ShellState shellState, final PrintWriter writer) {
+        this.shellState = shellState;
         this.writer = writer;
     }
 
@@ -89,7 +87,7 @@ class DateSetHandler extends AbstractCommandHandler {
                         "Invalid date: " + args.get("date"), e);
             }
         }
-        applicationState.put(SELECTED_DATE, selectedDate, LocalDate.class);
+        shellState.setDefaultDate(selectedDate);
         writer.println("Date set to " + selectedDate);
     }
 }

--- a/src/test/java/net/kemitix/journal/shell/CommandPromptTest.java
+++ b/src/test/java/net/kemitix/journal/shell/CommandPromptTest.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.Optional;
 
 import net.kemitix.journal.TypeSafeHashMap;
-import net.kemitix.journal.TypeSafeMap;
 
 /**
  * Tests for {@link CommandPrompt}.
@@ -32,8 +31,6 @@ public class CommandPromptTest {
 
     @Mock
     private CommandRouter commandRouter;
-
-    private TypeSafeMap applicationState;
 
     @Mock
     private BufferedReader reader;
@@ -50,9 +47,8 @@ public class CommandPromptTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        applicationState = new TypeSafeHashMap();
-        prompt = new CommandPrompt(commandRouter, applicationState, reader,
-                writer);
+        val shellState = new TypeSafeMapShellState(new TypeSafeHashMap());
+        prompt = new CommandPrompt(commandRouter, shellState, reader, writer);
     }
 
     @Test

--- a/src/test/java/net/kemitix/journal/shell/TypeSafeMapShellStateTest.java
+++ b/src/test/java/net/kemitix/journal/shell/TypeSafeMapShellStateTest.java
@@ -1,0 +1,80 @@
+package net.kemitix.journal.shell;
+
+import lombok.val;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+import net.kemitix.journal.LogEntryList;
+import net.kemitix.journal.TypeSafeHashMap;
+import net.kemitix.journal.TypeSafeMap;
+import net.kemitix.journal.model.ActionLogEntry;
+import net.kemitix.journal.model.EventLogEntry;
+import net.kemitix.journal.model.NoteLogEntry;
+
+/**
+ * Tests for {@link TypeSafeMapShellState}.
+ *
+ * @author pcampbell
+ */
+public class TypeSafeMapShellStateTest {
+
+    private TypeSafeMap map;
+
+    private TypeSafeMapShellState shellState;
+
+    @Before
+    public void setUp() throws Exception {
+        map = new TypeSafeHashMap();
+        shellState = new TypeSafeMapShellState(map);
+    }
+
+    @Test
+    public void shouldIsShuttingDown() throws Exception {
+        //given
+        assertThat(shellState.isShuttingDown()).as(
+                "Initial statue is not shutting down").isFalse();
+        //when
+        shellState.shutdown();
+        //then
+        assertThat(shellState.isShuttingDown()).as(
+                "Shutdown has been requested").isTrue();
+    }
+
+    @Test
+    public void shouldGetDefaultDate() throws Exception {
+        //given
+        val now = LocalDate.now();
+        val tomorrow = now.plusDays(1);
+        assertThat(shellState.getDefaultDate()).as(
+                "Initial default date is today").isEqualTo(now);
+        //when
+        shellState.setDefaultDate(tomorrow);
+        //then
+        assertThat(shellState.getDefaultDate()).as(
+                "Default date has been set to tomorrow").isEqualTo(tomorrow);
+    }
+
+        @Test
+    public void shouldGetLogEntryFromList() throws Exception {
+        //given
+        assertThat(shellState.getLogEntryFromList(0)).isEmpty();
+        val list = new LogEntryList();
+        val actionLogEntry = new ActionLogEntry();
+        val noteLogEntry = new NoteLogEntry();
+        val eventLogEntry = new EventLogEntry();
+        list.add(actionLogEntry);
+        list.add(noteLogEntry);
+        list.add(eventLogEntry);
+        //when
+        shellState.setLogEntryList(list);
+        //then
+        assertThat(shellState.getLogEntryFromList(0)).contains(actionLogEntry);
+        assertThat(shellState.getLogEntryFromList(1)).contains(noteLogEntry);
+        assertThat(shellState.getLogEntryFromList(2)).contains(eventLogEntry);
+    }
+
+}

--- a/src/test/java/net/kemitix/journal/shell/commands/ApplicationExitHandlerTest.java
+++ b/src/test/java/net/kemitix/journal/shell/commands/ApplicationExitHandlerTest.java
@@ -13,7 +13,7 @@ import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
 
-import net.kemitix.journal.TypeSafeMap;
+import net.kemitix.journal.shell.ShellState;
 
 /**
  * Tests for {@link ApplicationExitHandler}.
@@ -26,7 +26,7 @@ public class ApplicationExitHandlerTest {
     private ApplicationExitHandler handler;
 
     @Mock
-    private TypeSafeMap applicationState;
+    private ShellState shellState;
 
     private Map<String, String> args;
 
@@ -55,7 +55,7 @@ public class ApplicationExitHandlerTest {
         handler.handle(args);
         //then
         verify(writer).println("Exiting...");
-        verify(applicationState).remove("running");
+        verify(shellState).shutdown();
     }
 
 }

--- a/src/test/java/net/kemitix/journal/shell/commands/DailyCreateHandlerTest.java
+++ b/src/test/java/net/kemitix/journal/shell/commands/DailyCreateHandlerTest.java
@@ -16,12 +16,13 @@ import java.time.LocalDate;
 import java.util.HashMap;
 
 import net.kemitix.journal.TypeSafeHashMap;
-import net.kemitix.journal.TypeSafeMap;
 import net.kemitix.journal.model.DailyLog;
 import net.kemitix.journal.service.JournalService;
+import net.kemitix.journal.shell.ShellState;
+import net.kemitix.journal.shell.TypeSafeMapShellState;
 
 /**
- * .
+ * Tests for {@link DailyCreateHandler}.
  *
  * @author pcampbell
  */
@@ -35,7 +36,7 @@ public class DailyCreateHandlerTest {
     @Mock
     private DateSetHandler dateSetHandler;
 
-    private TypeSafeMap applicationState;
+    private ShellState shellState;
 
     private LocalDate now;
 
@@ -53,9 +54,9 @@ public class DailyCreateHandlerTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        applicationState = new TypeSafeHashMap();
+        shellState = new TypeSafeMapShellState(new TypeSafeHashMap());
         handler = new DailyCreateHandler(journalService, dateSetHandler,
-                applicationState, writer);
+                shellState, writer);
         now = LocalDate.now();
         args = new HashMap<>();
         yesterday = LocalDate.now().minusDays(1);
@@ -103,7 +104,7 @@ public class DailyCreateHandlerTest {
     public void shouldHandleNoArgsWithDefault() throws Exception {
         //given
         dailyLog = new DailyLog(yesterday);
-        applicationState.put("selected-date", yesterday, LocalDate.class);
+        shellState.setDefaultDate(yesterday);
         given(journalService.createDailyLog(yesterday)).willReturn(dailyLog);
         //when
         handler.handle(args);
@@ -119,7 +120,7 @@ public class DailyCreateHandlerTest {
         args.put("date", tomorrow.toString());
         given(journalService.createDailyLog(tomorrow)).willReturn(dailyLog);
         doAnswer(i -> {
-            applicationState.put("selected-date", tomorrow, LocalDate.class);
+            shellState.setDefaultDate(tomorrow);
             return null;
         }).when(dateSetHandler).handle(args);
         //when

--- a/src/test/java/net/kemitix/journal/shell/commands/DailyShowHandlerTest.java
+++ b/src/test/java/net/kemitix/journal/shell/commands/DailyShowHandlerTest.java
@@ -15,12 +15,11 @@ import java.io.PrintWriter;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Optional;
 
 import net.kemitix.journal.LogEntryGlyphs;
-import net.kemitix.journal.TypeSafeMap;
 import net.kemitix.journal.model.LogEntry;
 import net.kemitix.journal.service.JournalService;
+import net.kemitix.journal.shell.ShellState;
 
 /**
  * Tests for {@link DailyShowHandler}.
@@ -36,7 +35,7 @@ public class DailyShowHandlerTest {
     private JournalService journalService;
 
     @Mock
-    private TypeSafeMap applicationState;
+    private ShellState shellState;
 
     @Mock
     private LogEntryGlyphs glyphs;
@@ -69,11 +68,10 @@ public class DailyShowHandlerTest {
     public void shouldHandle() throws Exception {
         //given
         val now = LocalDate.now();
-        given(applicationState.get("selected date",
-                LocalDate.class)).willReturn(Optional.of(now));
         val logEntries = new ArrayList<LogEntry>();
         logEntries.add(logEntry1);
         logEntries.add(logEntry2);
+        given(shellState.getDefaultDate()).willReturn(now);
         given(journalService.getLogs(now)).willReturn(logEntries);
         given(glyphs.getGlyph(logEntry1)).willReturn("a");
         given(glyphs.getGlyph(logEntry2)).willReturn("b");

--- a/src/test/java/net/kemitix/journal/shell/commands/DateSetHandlerTest.java
+++ b/src/test/java/net/kemitix/journal/shell/commands/DateSetHandlerTest.java
@@ -16,8 +16,8 @@ import java.io.PrintWriter;
 import java.time.LocalDate;
 import java.util.HashMap;
 
-import net.kemitix.journal.TypeSafeMap;
 import net.kemitix.journal.shell.CommandHandlerException;
+import net.kemitix.journal.shell.ShellState;
 
 /**
  * Tests for {@link DateSetHandler}.
@@ -30,7 +30,7 @@ public class DateSetHandlerTest {
     private DateSetHandler handler;
 
     @Mock
-    private TypeSafeMap applicationState;
+    private ShellState shellState;
 
     @Mock
     private PrintWriter writer;
@@ -77,7 +77,7 @@ public class DateSetHandlerTest {
         handler.handle(args);
         //then
         verify(writer).println("Date set to " + today);
-        verify(applicationState).put("selected-date", today, LocalDate.class);
+        verify(shellState).setDefaultDate(today);
     }
 
     @Test
@@ -89,8 +89,7 @@ public class DateSetHandlerTest {
         handler.handle(args);
         //then
         verify(writer).println("Date set to " + tomorrow);
-        verify(applicationState).put("selected-date", tomorrow,
-                LocalDate.class);
+        verify(shellState).setDefaultDate(tomorrow);
     }
 
     @Rule


### PR DESCRIPTION
* Create new interface ShellState
* Create default implementation that simply wraps the TypeSafeMap interface (using TypeSafeMap is probably overkill, but I'll leave it there for now until the design has stabilised and I know I'll not need its flexibility)